### PR TITLE
docs: fix minor documentation to improve clarity and formatting

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,18 +8,19 @@ In the interest of fostering an open and welcoming environment, we as contributo
 
 Examples of behavior that contributes to creating a positive environment include:
 
-Using welcoming and inclusive language
-Being respectful of differing viewpoints and experiences
-Gracefully accepting constructive criticism
-Focusing on what is best for the community
-Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
 Examples of unacceptable behavior by participants include:
 
-The use of sexualized language or imagery and unwelcome sexual attention or advances
-Trolling, insulting/derogatory comments, and personal or political attacks
-Public or private harassment
-Publishing others’ private information, such as a physical or electronic address, without explicit permission
-Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ disclosure of security bugs. In those cases, please go through the process
 outlined on that page and do not file a public issue.
 
 ## Coding Style
-Run black isort and flake8 before submitting a PR.
+Run `black`, `isort`, and `flake8` before submitting a PR.
 ```
 black .
 isort

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A Momentumized, Adaptive, Dual Averaged Gradient Method for Stochastic Optimization
 
-Documentation availiable at https://madgrad.readthedocs.io/en/latest/.
+Documentation available at https://madgrad.readthedocs.io/en/latest/.
 
 
 ``` pip install madgrad ```


### PR DESCRIPTION
## Summary 
This PR addresses minor documentation fixes across multiple files:  

1. **README.md**  
   - Fixed typo: "availiable" → "available".  

2. **CONTRIBUTING.md**  
   - Added commas to the command `Run black, isort, and flake8...` for clarity.  

3. **CODE_OF_CONDUCT.md**  
   - Formatted "Our Standards" lists with proper Markdown bullet points.  

## Details  
- **README.md**: Corrected spelling error in documentation link.  
- **CONTRIBUTING.md**: Improved punctuation in linting instructions.  
- **CODE_OF_CONDUCT.md**: Fixed list syntax to ensure proper rendering.  

These changes enhance readability and consistency in project documentation.  
